### PR TITLE
llnode: added commands to look at the work queue

### DIFF
--- a/src/llnode.h
+++ b/src/llnode.h
@@ -35,6 +35,22 @@ class PrintCmd : public CommandBase {
   bool detailed_;
 };
 
+class GetActiveHandlesCmd : public CommandBase {
+ public:
+  ~GetActiveHandlesCmd() override {}
+
+  bool DoExecute(lldb::SBDebugger d, char** cmd,
+                 lldb::SBCommandReturnObject& result) override;
+};
+
+class GetActiveRequestsCmd : public CommandBase {
+ public:
+  ~GetActiveRequestsCmd() override {}
+
+  bool DoExecute(lldb::SBDebugger d, char** cmd,
+                 lldb::SBCommandReturnObject& result) override;
+};
+
 class ListCmd : public CommandBase {
  public:
   ~ListCmd() override {}


### PR DESCRIPTION
Added two new commands (getactivehandles and getactiverequests)
which returns all pending handles and requests (same return
given by process._getActiveHandles() and process._getActiveRequests()).
This is a proof-of-concept implementation that currently only works
using the node debug build. Probably some modifications on node are
necessary to make it work on the official build.